### PR TITLE
zapier integration

### DIFF
--- a/src/app/zapier.ts
+++ b/src/app/zapier.ts
@@ -1,0 +1,25 @@
+import fetch from 'node-fetch'
+
+export default async function handler(event: any) {
+    const discordEventId = process.env.ZAPER_ACTION_DISCORD_ID ?? ""
+
+    try {
+        // discord - zapier
+        const response = await fetch(`https://nla.zapier.com/api/v1/dynamic/exposed/${discordEventId}/execute/`,
+        { 
+            method: "POST",
+            headers: {
+                "x-api-key": process.env.ZAPIER_API_KEY ?? ""
+            },
+            body: JSON.stringify({ instructions: `Send a message to the discord channel to 
+                Checkout the latest blog post titled: ${event.title}, access it here: ${event.url}`})
+        })
+    
+        const result = await response.json()
+        console.log('result: ', result)
+    } catch (e) {
+        console.log(e)
+        console.log("fail")
+    }
+
+}


### PR DESCRIPTION
@albac - small PR to integrate the calls to zapier. There is a file zapier.ts in the src folder that has the handler function. Most of the work is just in configuring the zapier accounts. I only have discord right now. We cannot send images via discord unfortunately, only title and url. We can update the bot icon and name. We can send images through LinkedIn and Facebook. I did not hook up those integrations because I didn't want to use my own accounts for that. If we have some Pinesearch accounts for those platforms I can set that up.

Let me know if there need to changes.